### PR TITLE
Make closeable objects `Closeable`

### DIFF
--- a/src/ca/mta/iottestbed/logger/BufferedFileLogger.java
+++ b/src/ca/mta/iottestbed/logger/BufferedFileLogger.java
@@ -1,10 +1,11 @@
 package ca.mta.iottestbed.logger;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-public class BufferedFileLogger implements Logger {
+public class BufferedFileLogger implements Closeable, Logger {
     /**
      * BufferedLogger to write logs to.
      */
@@ -60,18 +61,9 @@ public class BufferedFileLogger implements Logger {
     /**
      * Close the BufferedFileLogger.
      * 
-     * @return {@code true} if successful.
+     * @throws IOException if an I/O error occurs
      */
-    public boolean close() {
-        // attempt to close
-        try {
-            writer.close();
-            return true;
-        } 
-        
-        // return false if failed
-        catch(IOException e) {
-            return false;
-        }
+    public void close() throws IOException {
+        writer.close();
     }
 }

--- a/src/ca/mta/iottestbed/meter/Meter.java
+++ b/src/ca/mta/iottestbed/meter/Meter.java
@@ -2,6 +2,7 @@ package ca.mta.iottestbed.meter;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.HashSet;
 
@@ -104,7 +105,11 @@ public class Meter {
             new Thread(new Runnable() {
                 @Override
                 public void run() {
-                    monitor(connection);
+                    try {
+                        monitor(connection);
+                    } catch (IOException ioe) {
+                        throw new UncheckedIOException(ioe);
+                    }
                 }
             }).start();
         }
@@ -120,7 +125,7 @@ public class Meter {
      * 
      * @param socket Socket to listen to.
      */
-    private void monitor(Connection connection) {
+    private void monitor(Connection connection) throws IOException {
         // listen while connection is active
         boolean active = true;
     

--- a/src/ca/mta/iottestbed/meter/Meter.java
+++ b/src/ca/mta/iottestbed/meter/Meter.java
@@ -124,6 +124,7 @@ public class Meter {
      * if a read fails.
      * 
      * @param socket Socket to listen to.
+     * @throws IOException if an I/O error occurs
      */
     private void monitor(Connection connection) throws IOException {
         // listen while connection is active

--- a/src/ca/mta/iottestbed/network/Connection.java
+++ b/src/ca/mta/iottestbed/network/Connection.java
@@ -100,6 +100,9 @@ public class Connection implements Closeable, Loggable {
 
     /**
      * Close the connection.
+     * 
+     * @throws IOException  if an I/O error occurs while closing the underlying
+     *                      socket
      */
     @Override
     public void close() throws IOException {

--- a/src/ca/mta/iottestbed/network/Connection.java
+++ b/src/ca/mta/iottestbed/network/Connection.java
@@ -1,5 +1,6 @@
 package ca.mta.iottestbed.network;
 
+import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -15,7 +16,7 @@ import ca.mta.iottestbed.logger.Logger;
  * @author Hayden Walker
  * @version 2023-06-14
  */
-public class Connection implements Loggable {
+public class Connection implements Closeable, Loggable {
     
     /**
      * Delimits 'tokens', or Strings that make up a message.
@@ -99,20 +100,16 @@ public class Connection implements Loggable {
 
     /**
      * Close the connection.
-     * 
-     * @return {@code true} if successful.
      */
-    public boolean close() {
-        // attempt to close
+    @Override
+    public void close() throws IOException {
         try {
             socket.close();
             log("Closed connection to " + getLocalHost());
-            return true;
         }
-        
         catch(IOException e) {
             log("Failed to close connection to " + getLocalHost());
-            return false;
+            throw new IOException("Failed to close connection to " + getLocalHost(), e);
         }
     }
 

--- a/src/ca/mta/iottestbed/network/Listener.java
+++ b/src/ca/mta/iottestbed/network/Listener.java
@@ -68,6 +68,9 @@ public class Listener implements Closeable, Loggable {
 
     /**
      * Close this Listener.
+     * 
+     * @throws IOException  if an I/O error occurs while closing the underlying
+     *                      socket
      */
     @Override
     public void close() throws IOException {

--- a/src/ca/mta/iottestbed/network/Listener.java
+++ b/src/ca/mta/iottestbed/network/Listener.java
@@ -1,5 +1,6 @@
 package ca.mta.iottestbed.network;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -14,7 +15,7 @@ import ca.mta.iottestbed.logger.Logger;
  * @author Hayden Walker
  * @version 2023-06-14
  */
-public class Listener implements Loggable {
+public class Listener implements Closeable, Loggable {
     
     /**
      * Socket to listen on.
@@ -67,21 +68,18 @@ public class Listener implements Loggable {
 
     /**
      * Close this Listener.
-     * 
-     * @return {@code true} if successful.
      */
-    public boolean close() {
+    @Override
+    public void close() throws IOException {
         // log success
         try {
             socket.close();
             log("Closed listener on port " + port);
-            return true;
         } 
-        
         // log failure
         catch(IOException e) {
             log("Failed to close listener on port " + port);
-            return false;
+            throw new IOException("Failed to close listener on port " + port, e);
         }
     }
 

--- a/src/ca/mta/iottestbed/sensor/Sensor.java
+++ b/src/ca/mta/iottestbed/sensor/Sensor.java
@@ -113,8 +113,13 @@ public class Sensor {
      
             // attempt to send message. if send fails, attempt to close.
             // if close is successful, remove connection.
-            if(!thisSocket.send(name, "report", "w:" + water, "e:" + power) && thisSocket.close()) {
-                iterator.remove();
+            if(!thisSocket.send(name, "report", "w:" + water, "e:" + power)) {
+                try {
+                    thisSocket.close();
+                    iterator.remove();
+                } catch (IOException ioe) {
+                    // close is unsuccessful, do not remove connection
+                }
             } 
         }
     }


### PR DESCRIPTION
By convention, objects that hold some resource that need to be closed should implement the [`java.io.Closeable`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/Closeable.html) interface. This PR modifies classes that consist of a `close()` method to implement the `java.io.Closeable` interface and updates relevant code accordingly.