### PR TITLE
Code Maintenance

### DIFF
--- a/src/main/java/ca/mta/iottestbed/logger/BufferedFileLogger.java
+++ b/src/main/java/ca/mta/iottestbed/logger/BufferedFileLogger.java
@@ -17,10 +17,10 @@ public class BufferedFileLogger implements Closeable, Logger {
     private FileWriter writer;
 
     /**
-     * Create a new BufferedFileLogger.
+     * Create a new {@code BufferedFileLogger}.
      * 
-     * @param file
-     * @throws IOException
+     * @param file the destination file
+     * @throws IOException if an I/O error occurs
      */
     public BufferedFileLogger(File file) throws IOException {
         logger = new BufferedLogger();
@@ -28,11 +28,7 @@ public class BufferedFileLogger implements Closeable, Logger {
         writer = new FileWriter(file, true);
     }
 
-    /**
-     * Log a message.
-     * 
-     * @param message Message to log.
-     */
+    /** {@inheritDoc} */
     @Override
     public void log(String message) {
         logger.log(message);

--- a/src/main/java/ca/mta/iottestbed/logger/BufferedLogger.java
+++ b/src/main/java/ca/mta/iottestbed/logger/BufferedLogger.java
@@ -35,14 +35,14 @@ public class BufferedLogger implements Logger {
     private boolean timestampEnabled;
 
     /**
-     * Create a new BufferedLogger.
+     * Create a new {@code BufferedLogger}.
      */
     public BufferedLogger() {
         this(DEFAULT_SIZE);
     }
 
     /**
-     * Create a new BufferedLogger with a preset initial size.
+     * Create a new {@code BufferedLogger} with the specified initial size.
      * 
      * @param size Initial size.
      * @throws IllegalArgumentException if {@code size <= 0}
@@ -57,11 +57,7 @@ public class BufferedLogger implements Logger {
         timestampEnabled = false;
     }
 
-    /**
-     * Log a message.
-     * 
-     * @param message Message to log.
-     */
+    /** {@inheritDoc} */
     @Override
     public void log(String message) {
         // add a timestamp
@@ -109,7 +105,7 @@ public class BufferedLogger implements Logger {
 
     /**
      * Check if the size needs to be increased, and call
-     * increaseLogSize() if it does.
+     * {@link #increaseLogSize()} if it does.
      */
     private void checkSize() {
         if(size >= capacity - 1) {

--- a/src/main/java/ca/mta/iottestbed/logger/BufferedLogger.java
+++ b/src/main/java/ca/mta/iottestbed/logger/BufferedLogger.java
@@ -1,5 +1,7 @@
 package ca.mta.iottestbed.logger;
 
+import java.util.Objects;
+
 /**
  * A buffered logger for storing diagnostic messages.
  * 
@@ -43,8 +45,12 @@ public class BufferedLogger implements Logger {
      * Create a new BufferedLogger with a preset initial size.
      * 
      * @param size Initial size.
+     * @throws IllegalArgumentException if {@code size <= 0}
      */
     public BufferedLogger(int size) {
+        if (size <= 0) {
+            throw new IllegalArgumentException("Invalid initial buffer size: " + size);
+        }
         this.size = 0;
         this.capacity = size;
         buffer = new char[this.capacity];
@@ -64,7 +70,7 @@ public class BufferedLogger implements Logger {
         }
 
         // write message to buffer
-        for(char character : message.toCharArray()) {
+        for(char character : Objects.toString(message).toCharArray()) {
             checkSize();
             buffer[size++] = character;
         }

--- a/src/main/java/ca/mta/iottestbed/logger/BufferedLogger.java
+++ b/src/main/java/ca/mta/iottestbed/logger/BufferedLogger.java
@@ -59,7 +59,7 @@ public class BufferedLogger implements Logger {
 
     /** {@inheritDoc} */
     @Override
-    public void log(String message) {
+    public synchronized void log(String message) {
         // add a timestamp
         if(timestampEnabled) {
             logTimestamp();
@@ -81,7 +81,7 @@ public class BufferedLogger implements Logger {
      * 
      * @return Buffer contents as a String.
      */
-    public String flush() {
+    public synchronized String flush() {
         String output = new String(buffer, 0, size);
         size = 0;
         return output;
@@ -90,7 +90,7 @@ public class BufferedLogger implements Logger {
     /**
      * Print and flush the buffer contents.
      */
-    public void printFlush() {
+    public synchronized void printFlush() {
         System.out.print(flush());
     }
 
@@ -99,7 +99,7 @@ public class BufferedLogger implements Logger {
      * 
      * @param status {@code true} to enable timestamps.
      */
-    public void timestampEnabled(boolean status) {
+    public synchronized void timestampEnabled(boolean status) {
         this.timestampEnabled = status;
     }
 
@@ -107,7 +107,7 @@ public class BufferedLogger implements Logger {
      * Check if the size needs to be increased, and call
      * {@link #increaseLogSize()} if it does.
      */
-    private void checkSize() {
+    private synchronized void checkSize() {
         if(size >= capacity - 1) {
             increaseLogSize();
         }
@@ -116,7 +116,7 @@ public class BufferedLogger implements Logger {
     /**
      * Add a timestamp to the log.
      */
-    private void logTimestamp() {
+    private synchronized void logTimestamp() {
         char[] date = ("[" + new Timestamp().toString() + "] ").toCharArray();
         for(int i = 0; i < date.length; i++) {
             checkSize();
@@ -127,7 +127,7 @@ public class BufferedLogger implements Logger {
     /**
      * Increase the size of the buffer by a factor of 2.
      */
-    private void increaseLogSize() {
+    private synchronized void increaseLogSize() {
         // calculate new size
         int newCapacity = 2 * capacity;
 

--- a/src/main/java/ca/mta/iottestbed/logger/BufferedLogger.java
+++ b/src/main/java/ca/mta/iottestbed/logger/BufferedLogger.java
@@ -133,9 +133,7 @@ public class BufferedLogger implements Logger {
         char[] newBuffer = new char[newCapacity];
         
         // copy buffer
-        for(int i = 0; i < capacity; i++) {
-            newBuffer[i] = buffer[i];
-        }
+        System.arraycopy(buffer, 0, newBuffer, 0, capacity);
 
         // replace buffer and capacity
         buffer = newBuffer;

--- a/src/main/java/ca/mta/iottestbed/logger/Logger.java
+++ b/src/main/java/ca/mta/iottestbed/logger/Logger.java
@@ -11,7 +11,7 @@ public interface Logger {
     /**
      * Log a message.
      * 
-     * @param messages Message to log.
+     * @param message Message to log.
      */
     public void log(String message);
 }

--- a/src/main/java/ca/mta/iottestbed/logger/Timestamp.java
+++ b/src/main/java/ca/mta/iottestbed/logger/Timestamp.java
@@ -17,7 +17,7 @@ public class Timestamp {
     private String timestamp;
 
     /**
-     * Create a new Timestamp.
+     * Create a new {@code Timestamp}.
      */
     public Timestamp() {
         DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.systemDefault()); 

--- a/src/main/java/ca/mta/iottestbed/meter/Meter.java
+++ b/src/main/java/ca/mta/iottestbed/meter/Meter.java
@@ -3,8 +3,11 @@ package ca.mta.iottestbed.meter;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import ca.mta.iottestbed.logger.BufferedLogger;
 import ca.mta.iottestbed.logger.Timestamp;
@@ -33,13 +36,13 @@ public class Meter {
     /**
      * Set of active connections.
      */
-    private HashSet<Connection> connections;
+    private Set<Connection> connections;
 
     /**
      * Logs for each sensor's data. Keys are sensor names,
      * and values are the logs.
      */
-    private HashMap<Connection, BufferedFileLogger> messageLogs;
+    private Map<Connection, BufferedFileLogger> messageLogs;
 
     /**
      * Meter's name.
@@ -57,11 +60,11 @@ public class Meter {
      * @param name Name of Meter.
      */
     public Meter(String name) {
-        this.connections = new HashSet<Connection>();
+        this.connections = Collections.synchronizedSet(new HashSet<Connection>());
         this.name = name;
         this.networkLog = new BufferedLogger();
         this.networkLog.timestampEnabled(true);
-        this.messageLogs = new HashMap<Connection, BufferedFileLogger>();
+        this.messageLogs = Collections.synchronizedMap(new HashMap<Connection, BufferedFileLogger>());
     }
        
     /**
@@ -199,8 +202,10 @@ public class Meter {
                     // }
 
                     // flush all sensor logs
-                    for(BufferedFileLogger sensorLog : messageLogs.values()) {
-                        sensorLog.write();
+                    synchronized (messageLogs) {
+                        for(BufferedFileLogger sensorLog : messageLogs.values()) {
+                            sensorLog.write();
+                        }
                     }
 
                     //TimeUnit.SECONDS.sleep(5);

--- a/src/main/java/ca/mta/iottestbed/meter/Meter.java
+++ b/src/main/java/ca/mta/iottestbed/meter/Meter.java
@@ -52,7 +52,7 @@ public class Meter {
     private BufferedLogger networkLog;
 
     /**
-     * Create a new Meter object.
+     * Create a new {@code Meter} object.
      * 
      * @param name Name of Meter.
      */
@@ -68,6 +68,7 @@ public class Meter {
      * Establish a connection with a sensor at a certain IP address.
      * 
      * @param ip IP address.
+     * @throws IOException if unable to connect to the specified address
      */
     private void addDevice(String ip) throws IOException {
         Connection connection = new Connection(ip, SENDING_PORT);

--- a/src/main/java/ca/mta/iottestbed/network/Connection.java
+++ b/src/main/java/ca/mta/iottestbed/network/Connection.java
@@ -5,8 +5,10 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.Socket;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import ca.mta.iottestbed.logger.Loggable;
 import ca.mta.iottestbed.logger.Logger;
@@ -32,7 +34,7 @@ public class Connection implements Closeable, Loggable {
     /**
      * Optional logger to write to.
      */
-    private HashSet<Logger> loggers;
+    private Set<Logger> loggers;
 
     /**
      * Create a new Connection from a Socket.
@@ -42,7 +44,7 @@ public class Connection implements Closeable, Loggable {
      */
     public Connection(Socket socket) {
         this.socket = Objects.requireNonNull(socket);
-        this.loggers = new HashSet<Logger>();
+        this.loggers = Collections.synchronizedSet(new HashSet<Logger>());
     }
 
     /**
@@ -160,8 +162,10 @@ public class Connection implements Closeable, Loggable {
      * @param message Message to log.
      */
     private void log(String message) {
-        for(Logger logger : loggers) {
-            logger.log(message);
+        synchronized (loggers) {
+            for(Logger logger : loggers) {
+                logger.log(message);
+            }
         }
     }
 

--- a/src/main/java/ca/mta/iottestbed/network/Connection.java
+++ b/src/main/java/ca/mta/iottestbed/network/Connection.java
@@ -6,6 +6,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.HashSet;
+import java.util.Objects;
 
 import ca.mta.iottestbed.logger.Loggable;
 import ca.mta.iottestbed.logger.Logger;
@@ -37,9 +38,10 @@ public class Connection implements Closeable, Loggable {
      * Create a new Connection from a Socket.
      * 
      * @param socket Socket to wrap.
+     * @throws NullPointerException if argument is {@code null}
      */
     public Connection(Socket socket) {
-        this.socket = socket;
+        this.socket = Objects.requireNonNull(socket);
         this.loggers = new HashSet<Logger>();
     }
 
@@ -134,6 +136,9 @@ public class Connection implements Closeable, Loggable {
     private String buildMessage(String ... tokens) {
         // use a StringBuilder
         StringBuilder out = new StringBuilder();
+
+        if (tokens == null)
+            return "null";
 
         // add each token
         for(int i = 0; i < tokens.length; i++) {

--- a/src/main/java/ca/mta/iottestbed/network/Listener.java
+++ b/src/main/java/ca/mta/iottestbed/network/Listener.java
@@ -4,7 +4,9 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
 
 import ca.mta.iottestbed.logger.Loggable;
 import ca.mta.iottestbed.logger.Logger;
@@ -30,7 +32,7 @@ public class Listener implements Closeable, Loggable {
     /**
      * Optional logger to write to.
      */
-    private HashSet<Logger> loggers;
+    private Set<Logger> loggers;
 
     /**
      * Start listening on a port.
@@ -41,7 +43,7 @@ public class Listener implements Closeable, Loggable {
     public Listener(int port) throws IOException {
         this.socket = new ServerSocket(port);
         this.port = port;
-        this.loggers = new HashSet<Logger>();
+        this.loggers = Collections.synchronizedSet(new HashSet<Logger>());
     }
 
     /**
@@ -92,8 +94,10 @@ public class Listener implements Closeable, Loggable {
      * @param message Message to log.
      */
     private void log(String message) {
-        for(Logger logger : loggers) {
-            logger.log(message);
+        synchronized (loggers) {
+            for(Logger logger : loggers) {
+                logger.log(message);
+            }
         }
     }
     

--- a/src/main/java/ca/mta/iottestbed/sensor/Sensor.java
+++ b/src/main/java/ca/mta/iottestbed/sensor/Sensor.java
@@ -93,11 +93,11 @@ public class Sensor {
     /**
      * Report sensor readings to connected meters.
      * 
-     * Will call {@code getWater()} and {@code getPower()}, format the readings into
-     * a {@link String}, and attempt to send that String to every {@link Socket} in {@code connections}.
+     * Will call {@link #getWater()} and {@link #getPower()}, format the readings into
+     * a {@link String}, and attempt to send that String to every {@link Socket} in {@link #connections}.
      * 
      * If a send fails, will attempt to close the connection to the socket, and remove the socket
-     * from {@code connections}.
+     * from {@link #connections}.
      */
     private void reportReadings() {
         // get readings

--- a/src/main/java/ca/mta/iottestbed/sensor/Sensor.java
+++ b/src/main/java/ca/mta/iottestbed/sensor/Sensor.java
@@ -1,7 +1,6 @@
 package ca.mta.iottestbed.sensor;
 
 import java.io.IOException;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 
@@ -74,7 +73,7 @@ public class Sensor {
      */
     private double getPower() {
         // get UNIX time and plug into sine wave with power consumption as amplitude
-        long milliseconds = new Date().getTime();
+        long milliseconds = System.currentTimeMillis();
         return power * Math.abs(Math.sin(milliseconds));
     }
 
@@ -85,7 +84,7 @@ public class Sensor {
      */
     private double getWater() {
         // get UNIX time and plug into sine wave with water consumption as amplitude
-        long milliseconds = new Date().getTime();
+        long milliseconds = System.currentTimeMillis();
         return water * Math.abs(Math.sin(milliseconds));
 
     }


### PR DESCRIPTION
This PR consists of various maintenance patches listed as follows:

- `ca.mta.iottestbed.logger.BufferedLogger`
  - Use `java.lang.System.arraycopy` for array copying (306c995)  
    This system method uses native code (i.e., some C/C++ code buried deep in JDK source files) and provides performance advantage over a classic `for`-loop when copying an array.
  - Check for invalid initial buffer size (ca24a59)
    If the initial buffer size is negative, the [constructor](https://github.com/Summer2023HW/access-control-java/blob/27c5cbc/src/main/java/ca/mta/iottestbed/logger/BufferedLogger.java#L42-L52) immediately throws a `java.lang.NegativeArraySizeException`. If the initial buffer size is zero, then any logging attempt throws a `java.lang.ArrayIndexOutOfBoundsException`. The constructor now explicitly checks for these two cases and throws a `java.lang.IllegalArgumentException` if needed.
  - Make the logging method `null`-safe (ca24a59)
    If the message is `null`, then the [first `for`-loop](https://github.com/Summer2023HW/access-control-java/blob/27c5cbc/src/main/java/ca/mta/iottestbed/logger/BufferedLogger.java#L66-L70) throws a `java.lang.NullPointerException`. The argument is now wrapped with the `java.util.Objects.toString(java.lang.Object)` method to make the logging method `null`-safe, i.e., if the argument is `null`, `"null"` is used as the message instead.
- `ca.mta.iottestbed.sensor.Sensor`
  - `getWater()` and `getPower()` methods now use direct system calls (776a7b8)  
    This version is functionally equivalent to the original version (as the `java.util.Time` constructor [makes the system call](https://github.com/openjdk/jdk11u/blob/master/src/java.base/share/classes/java/util/Date.java#L159-L168) to retrieve the current UNIX time anyway), but with less overhead.  
  Is the performance difference negligible? Well... probably.
- Make some internal data structures thread-safe (728e0b9)  
  Most data structures provided by the Java Collections Framework are not synchronized, i.e., they are vulnerable to all sorts of issues if accessed by multiple threads. To avoid such issues, collections that are accessed and/or modified by multiple threads are now explicitly synchronized. This comes with some performance penalty (due to synchronization overhead) but should prevent most (if not all) synchronization-related issues.
- Some Javadoc edits (7580f1a)